### PR TITLE
Add support for windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,13 @@
 * open plugins in the browser with a single command (e.g. in lazy, packer you can hover over a plugin name, simply press `gx` and you get to the github page of the plugin)
 * open github issues directly in the browser (e.g. `Fixes #22` opens `https://github.com/chrishrb/gx.nvim/issues/22`)
 * dependencies from `package.json` (e.g. line `"express": "^4.18.2",` in the `package.json` opens `https://www.npmjs.com/package/vue-router`)
+* support for macOS, Linux and Windows
 * more to come (jira issues, ..)
 
 ## ⚡️ Requirements
 
 * Neovim >= 0.5.0
-* macOS (`open`) or Linux (`xdg-open`)
+* macOS (`open`), Linux (`xdg-open`) or Windows (`powershell.exe start explorer.exe`)
 
 ## 📦 Installation
 

--- a/lua/gx/helper.lua
+++ b/lua/gx/helper.lua
@@ -22,6 +22,14 @@ local function table_contains(tbl, x)
   return found
 end
 
+-- Merge two tables to one
+function M.merge_tables(t1, t2)
+  for _, v in ipairs(t2) do
+    table.insert(t1, v)
+  end
+  return t1
+end
+
 -- check that cursor on uri in normal mode
 function M.check_if_cursor_on_url(mode, i, j)
   if mode ~= "n" then

--- a/lua/gx/init.lua
+++ b/lua/gx/init.lua
@@ -23,7 +23,10 @@ local function search_for_url()
     return
   end
 
-  local args = M.options.open_browser_args
+  local args = {}
+  for _, v in ipairs(M.options.open_browser_args) do
+    table.insert(args, v)
+  end
   table.insert(args, url)
 
   shell.execute_with_error(M.options.open_browser_app, args)

--- a/lua/gx/init.lua
+++ b/lua/gx/init.lua
@@ -23,13 +23,7 @@ local function search_for_url()
     return
   end
 
-  local args = {}
-  for _, v in ipairs(M.options.open_browser_args) do
-    table.insert(args, v)
-  end
-  table.insert(args, url)
-
-  shell.execute_with_error(M.options.open_browser_app, args)
+  shell.execute_with_error(M.options.open_browser_app, M.options.open_browser_args, url)
 end
 
 -- create keybindings
@@ -54,10 +48,11 @@ local function get_open_browser_app()
   return app
 end
 
-local function get_open_browser_args()
-  local args = {}
+-- get the args for opening the webbrowser
+local function get_open_browser_args(args)
   if sysname == "Windows_NT" then
-    args = { "start", "explorer.exe" }
+    local win_args = { "start", "explorer.exe" }
+    return helper.concat_tables(win_args, args)
   end
   return args
 end
@@ -68,7 +63,7 @@ local function with_defaults(options)
 
   return {
     open_browser_app = options.open_browser_app or get_open_browser_app(),
-    open_browser_args = options.open_browser_args or get_open_browser_args(),
+    open_browser_args = get_open_browser_args(options.open_browser_args or {}),
     handlers = {
       plugin = helper.ternary(options.handlers.plugin ~= nil, options.handlers.plugin, true),
       github = helper.ternary(options.handlers.github ~= nil, options.handlers.github, true),
@@ -83,11 +78,6 @@ end
 
 -- setup function
 function M.setup(options)
-  if not sysname == "Darwin" or not sysname == "Linux" then
-    notfier.error("Windows is not supported at the moment")
-    return
-  end
-
   M.options = with_defaults(options)
   bind_keys()
 end

--- a/lua/gx/init.lua
+++ b/lua/gx/init.lua
@@ -45,8 +45,18 @@ local function get_open_browser_app()
     app = "open"
   elseif sysname == "Linux" then
     app = "xdg-open"
+  elseif sysname == "Windows_NT" then
+    app = "powershell.exe"
   end
   return app
+end
+
+local function get_open_browser_args()
+  local args = {}
+  if sysname == "Windows_NT" then
+    args = { "start", "explorer.exe" }
+  end
+  return args
 end
 
 local function with_defaults(options)
@@ -55,7 +65,7 @@ local function with_defaults(options)
 
   return {
     open_browser_app = options.open_browser_app or get_open_browser_app(),
-    open_browser_args = options.open_browser_args or {},
+    open_browser_args = options.open_browser_args or get_open_browser_args(),
     handlers = {
       plugin = helper.ternary(options.handlers.plugin ~= nil, options.handlers.plugin, true),
       github = helper.ternary(options.handlers.github ~= nil, options.handlers.github, true),

--- a/lua/gx/shell.lua
+++ b/lua/gx/shell.lua
@@ -11,8 +11,14 @@ function shell.execute(command, args)
   return return_val, result
 end
 
-function shell.execute_with_error(command, args)
-  local return_val, _ = shell.execute(command, args)
+function shell.execute_with_error(command, args, url)
+  local shell_args = {}
+  for _, v in ipairs(args) do
+    table.insert(shell_args, v)
+  end
+  table.insert(shell_args, url)
+
+  local return_val, _ = shell.execute(command, shell_args)
 
   if return_val ~= 0 then
     local ret = {}


### PR DESCRIPTION
Normally explorer.exe always returns 1 since the built-in variable ERRORLEVEL is used for error checking. 
To correct this into the expected return code behavior the process is started through PowerShell.