### PR TITLE
rename merge_tables to concat_table

### DIFF
--- a/lua/gx/helper.lua
+++ b/lua/gx/helper.lua
@@ -22,8 +22,8 @@ local function table_contains(tbl, x)
   return found
 end
 
--- Merge two tables to one
-function M.merge_tables(t1, t2)
+-- Concat two tables to one
+function M.concat_tables(t1, t2)
   for _, v in ipairs(t2) do
     table.insert(t1, v)
   end


### PR DESCRIPTION
new name reflects behavior better, also fixes error in get_open_browser_args on windows

Before the change I would get this
![image](https://user-images.githubusercontent.com/10110847/236633758-9b125ad8-219a-430d-a5e0-8a8867b53d2f.png)

