### PR TITLE
fix: check for search_engine in user options

### DIFF
--- a/lua/gx/init.lua
+++ b/lua/gx/init.lua
@@ -77,7 +77,7 @@ local function with_defaults(options)
       search = helper.ternary(options.handlers.search ~= nil, options.handlers.search, true),
     },
     handler_options = {
-      search_engine = "google",
+      search_engine = options.handler_options.search_engine or "google",
     },
   }
 end


### PR DESCRIPTION
👋 me again 😅

I noticed that after #25, searches were still being done by google. this should fix it
