### PR TITLE
feat: allow the use of custom search engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ require("lazy").setup({
       },
       handler_options = {
         search_engine = "google", -- you can select between google, bing, duckduckgo, and ecosia
+        search_engine = "https://search.brave.com/search?q=", -- or you can pass in a custom search engine
       },
     } end,
   },

--- a/lua/gx/handlers/search.lua
+++ b/lua/gx/handlers/search.lua
@@ -17,11 +17,6 @@ function M.handle(mode, line, handler_options)
   end
 
   local search_engine_url = helper.get_search_url_from_engine(handler_options.search_engine)
-  if search_engine_url == nil then
-    require("gx.notifier").error("search engine " .. handler_options.search_engine .. " not found!")
-    return
-  end
-
   return search_engine_url .. helper.urlencode(search_pattern)
 end
 

--- a/lua/gx/helper.lua
+++ b/lua/gx/helper.lua
@@ -128,7 +128,9 @@ function M.get_search_url_from_engine(engine)
     duckduckgo = "https://duckduckgo.com/?q=",
     ecosia = "https://www.ecosia.org/search?q=",
   }
-
+  if search_url[engine] == nil then
+    return engine
+  end
   return search_url[engine]
 end
 


### PR DESCRIPTION
The current system only allows a hardcoded selection of search engines to be used.
With this change the user can use any search engine through the search_engine variable.
The downside is that now people can misconfigure the variable which will prevent search handler from working, but I think that's a fair trade off.