### PR TITLE
fix: don't create select mode keymap

### DIFF
--- a/lua/gx/init.lua
+++ b/lua/gx/init.lua
@@ -37,8 +37,7 @@ local function bind_keys()
   vim.g.netrw_nogx = 1 -- disable netrw gx
 
   local opts = { noremap = true, silent = true }
-  keymap("n", "gx", search_for_url, opts)
-  keymap("v", "gx", search_for_url, opts)
+  keymap({ "n", "x" }, "gx", search_for_url, opts)
 end
 
 -- get the app for opening the webbrowser


### PR DESCRIPTION
The option `v` actually creates a mapping in visual _and_ select mode. This is a common mistake. `x` is used for setting it only in visual mode.

Select mode is most commonly interacted with in snippets. 
