### PR TITLE
fix: improve git handler regexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ require("lazy").setup({
         search_engine = "google", -- you can select between google, bing, duckduckgo, and ecosia
         search_engine = "https://search.brave.com/search?q=", -- or you can pass in a custom search engine
         select_for_search = false, -- if your cursor is e.g. on a link, the pattern for the link AND for the word will always match. This disables this behaviour for default so that the link is opened without the select option for the word AND link
+
+        git_remotes = { "upstream", "origin" }, -- list of git remotes to search for git issue linking, in priority
+        git_remotes = function(fname) -- you can also pass in a function
+            if fname:match("myproject") then
+                return { "mygit" }
+            end
+            return { "upstream", "origin" }
+        end,
       },
     } end,
   },

--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ require("lazy").setup({
             end
             return { "upstream", "origin" }
         end,
+
+        git_remote_push = false, -- use the push url for git issue linking,
+        git_remote_push = function(fname) -- you can also pass in a function
+          return fname:match("myproject")
+        end,
       },
     } end,
   },

--- a/lua/gx/git.lua
+++ b/lua/gx/git.lua
@@ -16,13 +16,17 @@ local function parse_git_output(result)
   end
 end
 
-function M.get_remote_url(remotes, owner)
+function M.get_remote_url(remotes, push, owner)
   local notifier = require("gx.notifier")
 
   local url = nil
+  local path = vim.fn.expand("%:p:h")
   for _, remote in ipairs(remotes) do
-    local exit_code, result =
-      require("gx.shell").execute("git", { "remote", "get-url", "--push", remote })
+    local args = { "-C", path, "remote", "get-url", remote }
+    if push then
+      table.insert(args, "--push")
+    end
+    local exit_code, result = require("gx.shell").execute("git", args)
     if exit_code == 0 then
       url = parse_git_output(result)
       if url then

--- a/lua/gx/git.lua
+++ b/lua/gx/git.lua
@@ -16,18 +16,21 @@ local function parse_git_output(result)
   end
 end
 
-function M.get_remote_url(owner)
+function M.get_remote_url(remotes, owner)
   local notifier = require("gx.notifier")
 
-  local return_val, result =
-    require("gx.shell").execute("git", { "remote", "get-url", "--push", "origin" })
-
-  if return_val ~= 0 then
-    notifier.warn("No git information available!")
-    return
+  local url = nil
+  for _, remote in ipairs(remotes) do
+    local exit_code, result =
+      require("gx.shell").execute("git", { "remote", "get-url", "--push", remote })
+    if exit_code == 0 then
+      url = parse_git_output(result)
+      if url then
+        break
+      end
+    end
   end
 
-  local url = parse_git_output(result)
   if not url then
     notifier.warn("No remote git repository found!")
     return

--- a/lua/gx/git.lua
+++ b/lua/gx/git.lua
@@ -5,7 +5,7 @@ local function parse_git_output(result)
     return
   end
 
-  local domain, repository = result[1]:match("@(.*%..*):(.*)%.git$")
+  local domain, repository = result[1]:gsub("%.git%s*$", ""):match("@(.*%..*):(.*)$")
   if domain and repository then
     return "https://" .. domain .. "/" .. repository
   end
@@ -16,10 +16,11 @@ local function parse_git_output(result)
   end
 end
 
-function M.get_remote_url()
+function M.get_remote_url(owner)
   local notifier = require("gx.notifier")
 
-  local return_val, result = require("gx.shell").execute("git", { "remote", "get-url", "--push", "origin" })
+  local return_val, result =
+    require("gx.shell").execute("git", { "remote", "get-url", "--push", "origin" })
 
   if return_val ~= 0 then
     notifier.warn("No git information available!")
@@ -30,6 +31,10 @@ function M.get_remote_url()
   if not url then
     notifier.warn("No remote git repository found!")
     return
+  end
+  if type(owner) == "string" and owner ~= "" then
+    local domain, repository = url:match("^https?://([^/]+)/[^/]+/([^/]*)")
+    url = string.format("https://%s/%s/%s", domain, owner, repository)
   end
 
   return url

--- a/lua/gx/git.lua
+++ b/lua/gx/git.lua
@@ -5,12 +5,12 @@ local function parse_git_output(result)
     return
   end
 
-  local _, _, domain, repository = string.find(result[1], "^origin\t.*git@(.*%..*):(.*/.*).git")
+  local domain, repository = result[1]:match("@(.*%..*):(.*)%.git$")
   if domain and repository then
     return "https://" .. domain .. "/" .. repository
   end
 
-  local _, _, url = string.find(result[1], "origin\t(.*)%s")
+  local url = result[1]:gsub("%.git%s*$", ""):match("^https?://.+")
   if url then
     return url
   end
@@ -19,7 +19,7 @@ end
 function M.get_remote_url()
   local notifier = require("gx.notifier")
 
-  local return_val, result = require("gx.shell").execute("git", { "remote", "-v" })
+  local return_val, result = require("gx.shell").execute("git", { "remote", "get-url", "--push", "origin" })
 
   if return_val ~= 0 then
     notifier.warn("No git information available!")

--- a/lua/gx/git.lua
+++ b/lua/gx/git.lua
@@ -16,7 +16,7 @@ local function parse_git_output(result)
   end
 end
 
-function M.get_remote_url(remotes, push, owner)
+function M.get_remote_url(remotes, push, owner, repo)
   local notifier = require("gx.notifier")
 
   local url = nil
@@ -41,6 +41,9 @@ function M.get_remote_url(remotes, push, owner)
   end
   if type(owner) == "string" and owner ~= "" then
     local domain, repository = url:match("^https?://([^/]+)/[^/]+/([^/]*)")
+    if repo ~= "" then
+      repository = repo
+    end
     url = string.format("https://%s/%s/%s", domain, owner, repository)
   end
 

--- a/lua/gx/handlers/commit.lua
+++ b/lua/gx/handlers/commit.lua
@@ -8,13 +8,19 @@ local M = {
 }
 
 -- navigate to github url for commit
-function M.handle(mode, line, _)
+function M.handle(mode, line, handler_options)
   local pattern = "(%x%x%x%x%x%x%x+)"
   local commit_hash = helper.find(line, mode, pattern)
   if not commit_hash or #commit_hash > 40 then
     return
   end
-  local git_url = require("gx.git").get_remote_url()
+
+  local remotes = handler_options.git_remotes
+  if type(remotes) == "function" then
+    remotes = remotes(vim.fn.expand("%:p"))
+  end
+
+  local git_url = require("gx.git").get_remote_url(remotes)
   if not git_url then
     return
   end

--- a/lua/gx/handlers/commit.lua
+++ b/lua/gx/handlers/commit.lua
@@ -20,7 +20,12 @@ function M.handle(mode, line, handler_options)
     remotes = remotes(vim.fn.expand("%:p"))
   end
 
-  local git_url = require("gx.git").get_remote_url(remotes)
+  local push = handler_options.push
+  if type(push) == "function" then
+    push = push(vim.fn.expand("%:p"))
+  end
+
+  local git_url = require("gx.git").get_remote_url(remotes, push)
   if not git_url then
     return
   end

--- a/lua/gx/handlers/github.lua
+++ b/lua/gx/handlers/github.lua
@@ -9,14 +9,17 @@ local M = {
 
 -- navigate to neovim github plugin url
 function M.handle(mode, line, handler_options)
-  local match = helper.find(line, mode, "([%w-_]+#%d+)")
+  local match = helper.find(line, mode, "([%w-_]+/[%w-_]+#%d+)")
+  if not match then
+    match = helper.find(line, mode, "([%w-_]+#%d+)")
+  end
   if not match then
     match = helper.find(line, mode, "(#%d+)")
   end
   if not match then
     return
   end
-  local owner, issue = match:match("(.*)#(.+)")
+  local owner, repo, issue = match:match("([^/#]*)/?([^#]*)#(.+)")
 
   local remotes = handler_options.git_remotes
   if type(remotes) == "function" then
@@ -28,7 +31,7 @@ function M.handle(mode, line, handler_options)
     push = push(vim.fn.expand("%:p"))
   end
 
-  local git_url = require("gx.git").get_remote_url(remotes, push, owner)
+  local git_url = require("gx.git").get_remote_url(remotes, push, owner, repo)
   if not git_url then
     return
   end

--- a/lua/gx/handlers/github.lua
+++ b/lua/gx/handlers/github.lua
@@ -23,7 +23,12 @@ function M.handle(mode, line, handler_options)
     remotes = remotes(vim.fn.expand("%:p"))
   end
 
-  local git_url = require("gx.git").get_remote_url(remotes, owner)
+  local push = handler_options.push
+  if type(push) == "function" then
+    push = push(vim.fn.expand("%:p"))
+  end
+
+  local git_url = require("gx.git").get_remote_url(remotes, push, owner)
   if not git_url then
     return
   end

--- a/lua/gx/handlers/github.lua
+++ b/lua/gx/handlers/github.lua
@@ -8,7 +8,7 @@ local M = {
 }
 
 -- navigate to neovim github plugin url
-function M.handle(mode, line, _)
+function M.handle(mode, line, handler_options)
   local match = helper.find(line, mode, "([%w-_]+#%d+)")
   if not match then
     match = helper.find(line, mode, "(#%d+)")
@@ -18,7 +18,12 @@ function M.handle(mode, line, _)
   end
   local owner, issue = match:match("(.*)#(.+)")
 
-  local git_url = require("gx.git").get_remote_url(owner)
+  local remotes = handler_options.git_remotes
+  if type(remotes) == "function" then
+    remotes = remotes(vim.fn.expand("%:p"))
+  end
+
+  local git_url = require("gx.git").get_remote_url(remotes, owner)
   if not git_url then
     return
   end

--- a/lua/gx/handlers/github.lua
+++ b/lua/gx/handlers/github.lua
@@ -9,16 +9,20 @@ local M = {
 
 -- navigate to neovim github plugin url
 function M.handle(mode, line, _)
-  local pattern = "#(%d+)"
-  local github_issue = helper.find(line, mode, pattern)
-  if not github_issue then
+  local match = helper.find(line, mode, "([%w-_]+#%d+)")
+  if not match then
+    match = helper.find(line, mode, "(#%d+)")
+  end
+  if not match then
     return
   end
-  local git_url = require("gx.git").get_remote_url()
+  local owner, issue = match:match("(.*)#(.+)")
+
+  local git_url = require("gx.git").get_remote_url(owner)
   if not git_url then
     return
   end
-  return git_url .. "/issues/" .. github_issue
+  return git_url .. "/issues/" .. issue
 end
 
 return M

--- a/lua/gx/init.lua
+++ b/lua/gx/init.lua
@@ -98,6 +98,7 @@ local function with_defaults(options)
     handler_options = {
       search_engine = options.handler_options.search_engine or "google",
       select_for_search = options.handler_options.select_for_search or false,
+      git_remotes = options.handler_options.git_remotes or { "upstream", "origin" },
     },
   }
 end

--- a/lua/gx/init.lua
+++ b/lua/gx/init.lua
@@ -99,6 +99,7 @@ local function with_defaults(options)
       search_engine = options.handler_options.search_engine or "google",
       select_for_search = options.handler_options.select_for_search or false,
       git_remotes = options.handler_options.git_remotes or { "upstream", "origin" },
+      git_remote_push = options.handler_options.git_remote_push or false,
     },
   }
 end

--- a/test/spec/gx/handler_spec.lua
+++ b/test/spec/gx/handler_spec.lua
@@ -5,6 +5,9 @@ local assert = require("luassert")
 
 describe("test handler", function()
   local activated_handlers
+  local handler_options = {
+    git_remotes = { "upstream", "origin" },
+  }
 
   before_each(function()
     before_mock_filetype = vim.bo.filetype
@@ -26,14 +29,17 @@ describe("test handler", function()
 
     assert.same(
       { { ["name"] = "url", ["url"] = "https://github.com" } },
-      handler.get_url("v", "github.com", activated_handlers)
+      handler.get_url("v", "github.com", activated_handlers, handler_options)
     )
     assert.same(
       { { ["name"] = "url", ["url"] = "https://github.com" } },
-      handler.get_url("v", "https://github.com", activated_handlers)
+      handler.get_url("v", "https://github.com", activated_handlers, handler_options)
     )
-    assert.same({}, handler.get_url("v", '"example_user/example_plugin"', activated_handlers))
-    assert.same({}, handler.get_url("v", "Fixes #22", activated_handlers))
+    assert.same(
+      {},
+      handler.get_url("v", '"example_user/example_plugin"', activated_handlers, handler_options)
+    )
+    assert.same({}, handler.get_url("v", "Fixes #22", activated_handlers, handler_options))
   end)
 
   it("plugin handler on", function()
@@ -44,15 +50,15 @@ describe("test handler", function()
 
     assert.same(
       { { ["name"] = "url", ["url"] = "https://github.com" } },
-      handler.get_url("v", "github.com", activated_handlers)
+      handler.get_url("v", "github.com", activated_handlers, handler_options)
     )
     assert.same(
       { { ["name"] = "url", ["url"] = "https://github.com" } },
-      handler.get_url("v", "https://github.com", activated_handlers)
+      handler.get_url("v", "https://github.com", activated_handlers, handler_options)
     )
     assert.same(
       { { ["name"] = "nvim-plugin", ["url"] = "https://github.com/example_user/example_plugin" } },
-      handler.get_url("v", '"example_user/example_plugin"', activated_handlers)
+      handler.get_url("v", '"example_user/example_plugin"', activated_handlers, handler_options)
     )
   end)
 
@@ -65,15 +71,15 @@ describe("test handler", function()
 
     assert.same(
       { { ["name"] = "url", ["url"] = "https://github.com" } },
-      handler.get_url("v", "github.com", activated_handlers)
+      handler.get_url("v", "github.com", activated_handlers, handler_options)
     )
     assert.same(
       { { ["name"] = "url", ["url"] = "https://github.com" } },
-      handler.get_url("v", "https://github.com", activated_handlers)
+      handler.get_url("v", "https://github.com", activated_handlers, handler_options)
     )
     assert.same(
       { { ["name"] = "nvim-plugin", ["url"] = "https://github.com/example_user/example_plugin" } },
-      handler.get_url("v", '"example_user/example_plugin"', activated_handlers)
+      handler.get_url("v", '"example_user/example_plugin"', activated_handlers, handler_options)
     )
   end)
 
@@ -85,13 +91,16 @@ describe("test handler", function()
 
     assert.same(
       { { ["name"] = "url", ["url"] = "https://github.com" } },
-      handler.get_url("v", "github.com", activated_handlers)
+      handler.get_url("v", "github.com", activated_handlers, handler_options)
     )
     assert.same(
       { { ["name"] = "url", ["url"] = "https://github.com" } },
-      handler.get_url("v", "https://github.com", activated_handlers)
+      handler.get_url("v", "https://github.com", activated_handlers, handler_options)
     )
-    assert.same({}, handler.get_url("v", '"example_user/example_plugin"', activated_handlers))
+    assert.same(
+      {},
+      handler.get_url("v", '"example_user/example_plugin"', activated_handlers, handler_options)
+    )
   end)
 
   it("github handler on", function()
@@ -102,15 +111,15 @@ describe("test handler", function()
 
     assert.same(
       { { ["name"] = "url", ["url"] = "https://github.com" } },
-      handler.get_url("v", "github.com", activated_handlers)
+      handler.get_url("v", "github.com", activated_handlers, handler_options)
     )
     assert.same(
       { { ["name"] = "url", ["url"] = "https://github.com" } },
-      handler.get_url("v", "https://github.com", activated_handlers)
+      handler.get_url("v", "https://github.com", activated_handlers, handler_options)
     )
     assert.same(
       { { ["name"] = "github", ["url"] = "https://github.com/chrishrb/gx.nvim/issues/22" } },
-      handler.get_url("v", "Fixes #22", activated_handlers)
+      handler.get_url("v", "Fixes #22", activated_handlers, handler_options)
     )
   end)
 
@@ -123,12 +132,20 @@ describe("test handler", function()
     stub(helper, "get_filename")
     helper.get_filename.on_call_with().returns("package.json")
 
-    assert.same({
+    assert.same(
       {
-        ["name"] = "package_json",
-        ["url"] = "https://www.npmjs.com/package/@rushstack/eslint-patch",
+        {
+          ["name"] = "package_json",
+          ["url"] = "https://www.npmjs.com/package/@rushstack/eslint-patch",
+        },
       },
-    }, handler.get_url("v", '"@rushstack/eslint-patch": "^1.2.0",', activated_handlers))
+      handler.get_url(
+        "v",
+        '"@rushstack/eslint-patch": "^1.2.0",',
+        activated_handlers,
+        handler_options
+      )
+    )
 
     helper.get_filename:revert()
   end)
@@ -145,7 +162,7 @@ describe("test handler", function()
     assert.same({
       { ["name"] = "custom", ["url"] = "https://from.user.handler" },
       { ["name"] = "commit", ["url"] = "https://github.com/chrishrb/gx.nvim/commit/1a2b3c4" },
-    }, handler.get_url("v", "1a2b3c4", activated_handlers))
+    }, handler.get_url("v", "1a2b3c4", activated_handlers, handler_options))
   end)
 
   it("user defined handler instead of builtin handler", function()
@@ -158,7 +175,7 @@ describe("test handler", function()
 
     assert.same(
       { { ["url"] = "https://from.user.handler" } },
-      handler.get_url("v", "1a2b3c4", activated_handlers)
+      handler.get_url("v", "1a2b3c4", activated_handlers, handler_options)
     )
   end)
 end)

--- a/test/spec/gx/handlers/commit_handler_spec.lua
+++ b/test/spec/gx/handlers/commit_handler_spec.lua
@@ -1,30 +1,36 @@
 local handler = require("gx.handlers.commit")
+local handler_options = {
+  git_remotes = { "upstream", "origin" },
+}
 
 describe("commit_handler_does_work", function()
   it("doesn't see a hash with < 7 characters", function()
-    assert.is_nil(handler.handle("v", "1a2b3c"))
+    assert.is_nil(handler.handle("v", "1a2b3c", handler_options))
   end)
 
   it("does see a hash with 7 characters", function()
     assert.equals(
       "https://github.com/chrishrb/gx.nvim/commit/1a2b3c4",
-      handler.handle("v", "1a2b3c4")
+      handler.handle("v", "1a2b3c4", handler_options)
     )
   end)
 
   it("does see a hash with 10 characters", function()
     assert.equals(
       "https://github.com/chrishrb/gx.nvim/commit/1a2b3c4d5f",
-      handler.handle("v", "1a2b3c4d5f")
+      handler.handle("v", "1a2b3c4d5f", handler_options)
     )
   end)
 
   it("does see a hash with 40 characters", function()
     local hash = "1a2b3c4d5f1a2b3c4d5f1a2b3c4d5f1a2b3c4d5f"
-    assert.equals("https://github.com/chrishrb/gx.nvim/commit/" .. hash, handler.handle("v", hash))
+    assert.equals(
+      "https://github.com/chrishrb/gx.nvim/commit/" .. hash,
+      handler.handle("v", hash, handler_options)
+    )
   end)
 
   it("doesn't see a hash with > 40 characters", function()
-    assert.is_nil(handler.handle("v", "1a2b3c4d5f1a2b3c4d5f1a2b3c4d5f1a2b3c4d5fa"))
+    assert.is_nil(handler.handle("v", "1a2b3c4d5f1a2b3c4d5f1a2b3c4d5f1a2b3c4d5fa", handler_options))
   end)
 end)

--- a/test/spec/gx/handlers/github_handler_spec.lua
+++ b/test/spec/gx/handlers/github_handler_spec.lua
@@ -1,28 +1,43 @@
 local handler = require("gx.handlers.github")
+local handler_options = {
+  git_remotes = { "upstream", "origin" },
+}
 
 describe("github_handler_does_work", function()
   it("with_plain_issue_number", function()
-    assert.equals("https://github.com/chrishrb/gx.nvim/issues/2", handler.handle("v", "#2"))
+    assert.equals(
+      "https://github.com/chrishrb/gx.nvim/issues/2",
+      handler.handle("v", "#2", handler_options)
+    )
   end)
   it("with_text_before_issue_number", function()
-    assert.equals("https://github.com/chrishrb/gx.nvim/issues/22", handler.handle("v", "Fixes #22"))
+    assert.equals(
+      "https://github.com/chrishrb/gx.nvim/issues/22",
+      handler.handle("v", "Fixes #22", handler_options)
+    )
   end)
   it("with_text_after_issue_number", function()
     assert.equals(
       "https://github.com/chrishrb/gx.nvim/issues/40",
-      handler.handle("v", "#40 is a related issue")
+      handler.handle("v", "#40 is a related issue", handler_options)
     )
   end)
   it("with_text_all_around", function()
     assert.equals(
       "https://github.com/chrishrb/gx.nvim/issues/4",
-      handler.handle("v", "Fixes #4 once and for all")
+      handler.handle("v", "Fixes #4 once and for all", handler_options)
     )
   end)
   it("with_issue_number_in_parentheses", function()
     assert.equals(
       "https://github.com/chrishrb/gx.nvim/issues/51",
-      handler.handle("v", "This is a squashed PR (#51)")
+      handler.handle("v", "This is a squashed PR (#51)", handler_options)
+    )
+  end)
+  it("github_issue owner detection", function()
+    assert.equals(
+      "https://github.com/foouser/gx.nvim/issues/42",
+      handler.handle("v", "See foouser#42", handler_options)
     )
   end)
 end)

--- a/test/spec/gx/handlers/github_handler_spec.lua
+++ b/test/spec/gx/handlers/github_handler_spec.lua
@@ -40,4 +40,10 @@ describe("github_handler_does_work", function()
       handler.handle("v", "See foouser#42", handler_options)
     )
   end)
+  it("parses owner/repo#issue format", function()
+    assert.equals(
+      "https://github.com/neovim/neovim/issues/23943",
+      handler.handle("v", "Waiting on upstream neovim/neovim#23943", handler_options)
+    )
+  end)
 end)


### PR DESCRIPTION
* Uses `git remote set-url --push origin` to get the url instead of parsing from `git remote -v`
* Clean up regex matching code, use `string.match` instead of `string.find`
* Allow optional .git for ssh remotes
* Detect owner in owner#issue format
* Detect owner, repo in owner/repo#issue format
* Add `handler_options.git_remotes` that takes a `string[]` or `function(fname: string): string[]`, indicating the order of remote names to search for a valid URL

Fixes #45, #56
Supersedes #24