### PR TITLE
Fix github handler not matching github issue inside braces

### DIFF
--- a/lua/gx/handlers/github.lua
+++ b/lua/gx/handlers/github.lua
@@ -8,7 +8,7 @@ local M = {
 
 -- navigate to neovim github plugin url
 function M.handle(mode, line, _)
-  local pattern = "%a*%s#(%d*)"
+  local pattern = "#(%d+)"
   local github_issue = helper.find(line, mode, pattern)
   if not github_issue then
     return

--- a/test/spec/gx/handlers/github_handler_spec.lua
+++ b/test/spec/gx/handlers/github_handler_spec.lua
@@ -1,11 +1,28 @@
 local handler = require("gx.handlers.github")
 
 describe("github_handler_does_work", function()
-  it("github_issue", function()
+  it("with_plain_issue_number", function()
+    assert.equals("https://github.com/chrishrb/gx.nvim/issues/2", handler.handle("v", "#2"))
+  end)
+  it("with_text_before_issue_number", function()
     assert.equals("https://github.com/chrishrb/gx.nvim/issues/22", handler.handle("v", "Fixes #22"))
+  end)
+  it("with_text_after_issue_number", function()
     assert.equals(
-      "https://github.com/chrishrb/gx.nvim/issues/2",
-      handler.handle("v", "New Error #2")
+      "https://github.com/chrishrb/gx.nvim/issues/40",
+      handler.handle("v", "#40 is a related issue")
+    )
+  end)
+  it("with_text_all_around", function()
+    assert.equals(
+      "https://github.com/chrishrb/gx.nvim/issues/4",
+      handler.handle("v", "Fixes #4 once and for all")
+    )
+  end)
+  it("with_issue_number_in_parentheses", function()
+    assert.equals(
+      "https://github.com/chrishrb/gx.nvim/issues/51",
+      handler.handle("v", "This is a squashed PR (#51)")
     )
   end)
 end)


### PR DESCRIPTION
When one uses squash to merge PR-s, the issue number is in parentheses.
The github handler pattern failed to match those issues.

This change fixes that and adds some test-cases for various edge-cases
as well.
