### PR TITLE
Allow full overriding of open_browser_args on Windows

### DIFF
--- a/lua/gx/init.lua
+++ b/lua/gx/init.lua
@@ -79,10 +79,10 @@ local function get_open_browser_app()
 end
 
 -- get the args for opening the webbrowser
-local function get_open_browser_args(args)
+local function get_open_browser_args()
+  local args = {}
   if sysname == "Windows_NT" then
-    local win_args = { "start", "explorer.exe" }
-    return helper.concat_tables(win_args, args)
+    args = { "start", "explorer.exe" }
   end
   return args
 end
@@ -93,7 +93,7 @@ local function with_defaults(options)
 
   return {
     open_browser_app = options.open_browser_app or get_open_browser_app(),
-    open_browser_args = get_open_browser_args(options.open_browser_args or {}),
+    open_browser_args = options.open_browser_args or get_open_browser_args(),
     handlers = options.handlers or {},
     handler_options = {
       search_engine = options.handler_options.search_engine or "google",


### PR DESCRIPTION
Thanks for the great plugin!

On Windows, when trying to configure custom `open_browser_args`, I noticed that default `start` and `explorer.exe` args are _always_ forcibly prepended to the args list, no matter what is configured. I'm not sure this makes sense, as it severely restricts the available browser opening strategies for Windows users.

The change I'm proposing makes the `open_browser_args` behavior more consistent with the `open_browser_app` config, i.e. if the user provides a custom args list, assume they know what they want and use exactly what is provided.

I hope this sounds reasonable to you, but I do realize it could be a breaking change for Windows users who currently have custom `explorer.exe`-specific flags configured...although none of those [flags](https://www.geoffchappell.com/studies/windows/shell/explorer/cmdline.htm) seem very useful for link opening? Happy to take any feedback and suggestions.