### PR TITLE
fix: remove redundant `owner` and `repo` check, that adds useless entry, fixes #71

### DIFF
--- a/lua/gx/git.lua
+++ b/lua/gx/git.lua
@@ -43,9 +43,6 @@ function M.get_remote_url(remotes, push, owner, repo)
     url = discover_remote(remotes, push, vim.loop.cwd())
   end
 
-  if not url and (owner ~= "" and repo ~= "") then -- fallback to github if owner and repo are present
-    url = "https://github.com/foo/bar"
-  end
   if not url then
     notifier.warn("No remote git repository found!")
     return


### PR DESCRIPTION
This useless entry `https://github.com/foo/bar` sometimes shows up for me, but I forgot how.

Looking at the code, it seems to have no purpose. The check here is repeated later on.