### PR TITLE
Add optional callback to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ require("lazy").setup({
     config = function() require("gx").setup {
       open_browser_app = "os_specific", -- specify your browser app; default for macOS is "open", Linux "xdg-open" and Windows "powershell.exe"
       open_browser_args = { "--background" }, -- specify any arguments, such as --background for macOS' "open".
+
+      open_callback = false, -- optional callback function to be called with the selected url on open
+      open_callback = function(url)
+        vim.fn.setreg("+", url) -- for example, you can set the url to clipboard here
+      end,
+
       handlers = {
         plugin = true, -- open plugin links in lua (e.g. packer, lazy, ..)
         github = true, -- open github issues

--- a/lua/gx/init.lua
+++ b/lua/gx/init.lua
@@ -42,6 +42,9 @@ function M.open(mode, line)
   if #urls == 0 then
     return
   elseif #urls == 1 then
+    if M.options.open_callback then
+      M.options.open_callback(urls[1].url)
+    end
     return require("gx.shell").execute_with_error(
       M.options.open_browser_app,
       M.options.open_browser_args,
@@ -57,7 +60,9 @@ function M.open(mode, line)
       if not selected then
         return
       end
-
+      if M.options.open_callback then
+        M.options.open_callback(selected.url)
+      end
       return require("gx.shell").execute_with_error(
         M.options.open_browser_app,
         M.options.open_browser_args,
@@ -97,6 +102,7 @@ local function with_defaults(options)
   return {
     open_browser_app = options.open_browser_app or get_open_browser_app(),
     open_browser_args = options.open_browser_args or get_open_browser_args(),
+    open_callback = options.open_callback or false,
     handlers = options.handlers or {},
     handler_options = {
       search_engine = options.handler_options.search_engine or "google",


### PR DESCRIPTION
I really like the handler logic built into this plugin, but can't use the open command easily over ssh. I was able to work around it by inserting a callback to stick the processed url into the clipboard when open is triggered. Figured this feature might be useful to others as well. A callback to insert to clipboard + osc52 + clipboard watching script achieves the same behavior over ssh as default gx on a local machine.