### PR TITLE
fix(git): don't define global M

### DIFF
--- a/lua/gx/git.lua
+++ b/lua/gx/git.lua
@@ -1,4 +1,4 @@
-M = {}
+local M = {}
 
 local function parse_git_output(result)
   if not result or #result < 1 then


### PR DESCRIPTION
One-word change to avoid defining a global variable `M` in `git.lua`.

Fixes #84 