### PR TITLE
Fix handler_options defaulting logic

### DIFF
--- a/lua/gx/init.lua
+++ b/lua/gx/init.lua
@@ -93,17 +93,17 @@ end
 local function with_defaults(options)
   options = options or {}
   options.handler_options = options.handler_options or {}
+  options.handler_options.search_engine = options.handler_options.search_engine or "google"
+  options.handler_options.select_for_search = options.handler_options.select_for_search or false
+  options.handler_options.git_remotes = options.handler_options.git_remotes
+    or { "upstream", "origin" }
+  options.handler_options.git_remote_push = options.handler_options.git_remote_push or false
 
   return {
     open_browser_app = options.open_browser_app or get_open_browser_app(),
     open_browser_args = options.open_browser_args or get_open_browser_args(),
     handlers = options.handlers or {},
-    handler_options = {
-      search_engine = options.handler_options.search_engine or "google",
-      select_for_search = options.handler_options.select_for_search or false,
-      git_remotes = options.handler_options.git_remotes or { "upstream", "origin" },
-      git_remote_push = options.handler_options.git_remote_push or false,
-    },
+    handler_options = options.handler_options,
   }
 end
 


### PR DESCRIPTION
The defaulting should not delete user-provided keys from handler_options
as it is expected that user_provided handlers have their own options.
