### PR TITLE
Allow "terraform" filetype for terraform handler

### DIFF
--- a/lua/gx/handlers/terraform.lua
+++ b/lua/gx/handlers/terraform.lua
@@ -4,7 +4,7 @@ local helper = require("gx.helper")
 local M = {
   -- every filetype and filename
   name = "terraform",
-  filetype = { "hcl" },
+  filetype = { "hcl", "terraform" },
   filename = nil,
 }
 


### PR DESCRIPTION
"terraform" filetype also exists (and I believe is more common than "hcl"), it makes sense to support it