### PR TITLE
Support asterisks in URLs

### DIFF
--- a/lua/gx/handlers/url.lua
+++ b/lua/gx/handlers/url.lua
@@ -10,7 +10,7 @@ local M = {
 
 -- get url from line (with http/s)
 function M.handle(mode, line, _)
-  local pattern = "(https?://[a-zA-Z%d_/%%%-%.~@\\+#=?&:]+)"
+  local pattern = "(https?://[a-zA-Z%d_/%%%-%.~@\\+#=?&:*]+)"
   local url = helper.find(line, mode, pattern)
 
   -- match url without http(s)

--- a/test/spec/gx/handlers/url_spec.lua
+++ b/test/spec/gx/handlers/url_spec.lua
@@ -46,10 +46,7 @@ describe("url_parser_does_work", function()
     )
     assert.equals(
       "https://crontab.guru/#0_3_*_*_*",
-      handler.handle(
-        "n",
-        "https://crontab.guru/#0_3_*_*_*"
-      )
+      handler.handle("n", "https://crontab.guru/#0_3_*_*_*")
     )
   end)
 

--- a/test/spec/gx/handlers/url_spec.lua
+++ b/test/spec/gx/handlers/url_spec.lua
@@ -44,6 +44,13 @@ describe("url_parser_does_work", function()
         "https://golang-jwt.github.io/jwt/usage/signing\\_methods/#signing-methods-and-key-types"
       )
     )
+    assert.equals(
+      "https://crontab.guru/#0_3_*_*_*",
+      handler.handle(
+        "n",
+        "https://crontab.guru/#0_3_*_*_*"
+      )
+    )
   end)
 
   it("urls in python", function()


### PR DESCRIPTION
Thanks for a neat plugin! I ran into an issue where it was stopping parsing at asterisks in URLs, so I added them to the URL pattern.

Asterisks can appear in URLs like this:

* [`https://crontab.guru/#0_3_*_*_*`](https://crontab.guru/#0_3_*_*_*)
* http://wayback.archive.org/web/*/http://google.com